### PR TITLE
Shebang für Python3

### DIFF
--- a/Bestandsabgleich
+++ b/Bestandsabgleich
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import pandas as pd
 import requests
 import urllib.parse


### PR DESCRIPTION
Damit kann das Skript auf der Kommandozeile direkt mit `./Bestandsabgleich` statt mit `python3 Bestandsabgleich` gestartet werden.